### PR TITLE
CSARv2

### DIFF
--- a/Components/CSARBot.lua
+++ b/Components/CSARBot.lua
@@ -1,19 +1,33 @@
-local csb = {}
--- Created by combining CasBot.lua from WWXOS (url) by EatLeadCobra with ideas from
+CSB = {}
+-- Created by combining CasBot.lua from WWXOS (url) by EatLeadCobra with
 -- autoCSAR.lua and csarManager2.lua from the DML package (url) by cfrag
-local searchStackInterval = 30
+local searchStackInterval = 20
 local trackCsarInterval = 2
 local csarStackRadius = 1000
 local csarStackHeight = 1000
 local csarZoneRadius = 10000
-local csarTimeLimit = 3599
-local csarReassignTime = 299
+local csarTimeLimitMax = 2400
+local csarTimeLimitMin = 1200
 local csarPickupRadius = 30
 local csarHoverRadius = 20
 local csarHoverAgl = 30
 local csarHoverTime = 20
 local csarBreakCoverRange = 1500
+local csarMaxDisplayed = 6
+local csarTroopMass = 130
+local csarTroopVol = 2
+local csarAutoProcRadius = 3000
+local genCsarCounter = 25
 
+local csarCheckIns = {
+    [1] = {},
+    [2] = {}
+}
+local csarMissions = {
+    [1] = {},
+    [2] = {}
+}
+local floorIsLava = {}
 local smokeColors = {
     [0] = "green",
     [1] = "red",
@@ -26,10 +40,6 @@ local previousLists = {
     [2] = {}
 }
 local currentLists = {
-    [1] = {},
-    [2] = {}
-}
-local assignments = {
     [1] = {},
     [2] = {}
 }
@@ -51,86 +61,60 @@ local csarPoints = {
 }
 local csarFreqs = {
     [1] = {
-        ["VHF_FM"] = {
-            [0] = 41000000,
-            [1] = 42000000,
-            [2] = 43000000,
-            [3] = 44000000,
-            [4] = 45000000,
-            [5] = 46000000,
-            [6] = 47000000,
-            [7] = 48000000,
-            [8] = 49000000,
-        },
         ["NDB"] = {
-            [0] = 410000,
-            [1] = 440000,
-            [2] = 470000,
-            [3] = 500000,
-            [4] = 530000,
-            [5] = 560000,
-            [6] = 590000,
-            [7] = 620000,
-            [8] = 650000,
+            20,
+            69
         },
         ["TACAN"] = {
-            [0] = 41,
-            [1] = 42,
-            [2] = 43,
-            [3] = 44,
-            [4] = 45,
-            [5] = 46,
-            [6] = 47,
-            [7] = 48,
-            [8] = 49,
+            10,
+            59
         }
     },
     [2] = {
-        ["VHF_FM"] = {
-            [0] = 51000000,
-            [1] = 52000000,
-            [2] = 53000000,
-            [3] = 54000000,
-            [4] = 55000000,
-            [5] = 56000000,
-            [6] = 57000000,
-            [7] = 58000000,
-            [8] = 59000000,
-        },
         ["NDB"] = {
-            [0] = 710000,
-            [1] = 740000,
-            [2] = 770000,
-            [3] = 800000,
-            [4] = 830000,
-            [5] = 860000,
-            [6] = 890000,
-            [7] = 920000,
-            [8] = 950000,
+            71,
+            120
         },
         ["TACAN"] = {
-            [0] = 51,
-            [1] = 52,
-            [2] = 53,
-            [3] = 54,
-            [4] = 55,
-            [5] = 56,
-            [6] = 57,
-            [7] = 58,
-            [8] = 59,
+            61,
+            110,
         }
     }
 }
-local csarCounter = {
+local csarFreqCollisions = {
     [1] = {
-        ["VHF_FM"] = 0,
-        ["NDB"] = 0,
-        ["TACAN"] = 0
+        ["NDB"] = {
+            33,
+            34,
+            36,
+            37,
+            43
+        },
+        ["TACAN"] = {
+            21,
+
+        }
     },
     [2] = {
-        ["VHF_FM"] = 0,
-        ["NDB"] = 0,
-        ["TACAN"] = 0
+        ["NDB"] = {
+        },
+        ["TACAN"] = {
+            71,
+            73,
+            75,
+            79,
+            84,
+            85,
+            87,
+            89,
+            90,
+            92,
+            95,
+            100,
+            106,
+            107,
+            109
+        }
     }
 }
 local csarBases = {
@@ -141,15 +125,7 @@ local csarBases = {
         [1] = "Blue Forward Field Hospital"
     }
 }
-local vhfFmHomingCapable = {
-    ["Mi-24P"] = true,
-    ["Mi-8MT"] = true,
-    ["UH-1H"] = true
-}
-local tacanOnly = {
-    ["AV8BNA"] = true
-}
-function csb.load()
+function CSB.load()
     local redZone = trigger.misc.getZone(stackZones[1])
     local blueZone = trigger.misc.getZone(stackZones[2])
     local redCsarZone = trigger.misc.getZone(csarZones[1])
@@ -169,20 +145,23 @@ function csb.load()
         csarPoints[2] = {x=blueCsarZone.point.x, y = land.getHeight({x = blueCsarZone.point.x, y = blueCsarZone.point.z})+3, z = blueCsarZone.point.z}
         trigger.action.circleToAll(2,DrawingTools.newMarkId(),csarPoints[2],csarZoneRadius,{0,0,1,0.6},{0,0,0,0}, 4, true, nil)
         trigger.action.textToAll(2, DrawingTools.newMarkId(), csarPoints[2], {0,0,1,0.6}, {1,1,1,0.9}, 10, true, "CSAR Coverage")
-        csb.main()
     end
+    CSB.buildLavaList()
+    CSB.main()
     for c = 1, 2 do
         for z = 1, #csarBases[c] do
             DrawingTools.drawHealth(trigger.misc.getZone(csarBases[c][z]).point, c, 500)
         end
     end
 end
-function csb.main()
-    csb.searchCsarStacks()
-    csb.trackCsar()
+function CSB.main()
+    CSB.searchCsarStacks()
+    CSB.trackCsar()
+    --timer.scheduleFunction(CSB.debugCsarGeneration,nil,timer.getTime()+10)
+    CSB.refreshCsarTransmissions()
 end
-function csb.searchCsarStacks()
-    timer.scheduleFunction(csb.searchCsarStacks, nil, timer:getTime() + searchStackInterval)
+function CSB.searchCsarStacks()
+    timer.scheduleFunction(CSB.searchCsarStacks, nil, timer:getTime() + searchStackInterval)
     for c = 1,2 do
         local volS = {
             id = world.VolumeType.SPHERE,
@@ -198,13 +177,22 @@ function csb.searchCsarStacks()
                 local playerCoalition = foundItem:getCoalition()
                 local playerGroup = foundItem:getGroup()
                 local playerTypeName = foundItem:getTypeName()
+                local playerUnitName = foundItem:getName()
                 if playerGroup then
                     local playerGroupID = playerGroup:getID()
+                    local playerGroupName = playerGroup:getName()
                     if foundPlayerName and playerCoalition and playerGroupID then
                         env.info("Found player: "..foundPlayerName, false)
-                        if assignments[c][foundPlayerName] == nil then
-                            env.info("player added to list: "..foundPlayerName, false)
-                            currentLists[c][foundPlayerName] = {name = foundPlayerName, coalition = playerCoalition, groupID = playerGroupID, typeName = playerTypeName}
+                        if csarCheckIns[c][foundPlayerName] == nil then
+                            env.info("player added to csar check-in list: "..foundPlayerName, false)
+                            currentLists[c][foundPlayerName] = {name = foundPlayerName, coalition = playerCoalition, groupID = playerGroupID, groupName = playerGroupName, typeName = playerTypeName, unitName = playerUnitName}
+                        else
+                            env.info("player already checked-in for CSAR: "..foundPlayerName, false)
+                            env.info("csarMission count for " .. c .. " is " .. #csarMissions[c], false)
+                            if #csarMissions[c] < 4 then
+                                env.info("calling csarCheckIn for: " .. foundPlayerName)
+                                CSB.csarCheckIn(foundPlayerName, playerCoalition, playerGroupID, playerGroupName, playerTypeName, playerUnitName, true)
+                            end
                         end
                     end
                 end
@@ -212,16 +200,11 @@ function csb.searchCsarStacks()
         end
         world.searchObjects(Object.Category.UNIT, volS, ifFound)
         for k,v in pairs(currentLists[c]) do
-            if previousLists[c][k] and assignments[c][k] == nil or previousLists[c][k] and (assignments[c][k].startTime > csarReassignTime) then
-                if assignments[c][k] ~= nil then
-                    csb.cleanupCsarGroup(assignments[c][k])
-                    trigger.action.outTextForGroup(assignments[c][k].groupID, assignments[c][k].fName.."'s locator Beacon no longer transmitting...", 30, false)
-                    assignments[c][k] = nil
-                end
-                csb.assignCsar(v.name, v.coalition, v.groupID, v.typeName)
-                env.info("player assigned: ".. v.name, false)
+            if previousLists[c][k] then
+                CSB.csarCheckIn(v.name, v.coalition, v.groupID, v.groupName, v.typeName, v.unitName)
+                env.info("player checked-in for CSAR: ".. v.name, false)
             else
-                trigger.action.outTextForGroup(v.groupID, "You are on station for CSAR. Stand by for assignment.", 20, false)
+                trigger.action.outTextForGroup(v.groupID, "You are on station for CSAR. Stand by for tasking.", 20, false)
             end
         end
         previousLists[c] = {}
@@ -229,269 +212,563 @@ function csb.searchCsarStacks()
         currentLists[c] = {}
     end
 end
-function csb.assignCsar(playerName, coalitionId, playerGroupID, typeName)
-    local smokeNum = math.random(0,4)
-    local fName = ""
-    local freqType = "VHF_FM"
-    local modulation = 1
-    local csarGearGroupName = nil
-    if randomNames and randomNames.getNewName then
-        fName = randomNames.getNewName(coalitionId)
+function CSB.csarCheckIn(playerName, coalitionId, playerGroupID, playerGroupName, typeName, unitName, prev)
+    if not prev then prev = false end
+    if not csarCheckIns[coalitionId][playerName] then
+        csarCheckIns[coalitionId][playerName] = {groupID = playerGroupID, groupName = playerGroupName, typeName = typeName, unitName = unitName, onBoard = {}}
     end
-    local csarGroupName = DF_UTILS.spawnGroupWide("SOS-".. coalitionId,csarPoints[coalitionId],"clone",csarZoneRadius, false, {"LAND","ROAD"}, fName)
-    if csarGroupName then
-        local csarGroup = Group.getByName(csarGroupName)
-        if csarGroup then
-            local csarPoint = csarGroup:getUnit(1):getPoint()
-            if fName == "" then fName = csarGroupName end
-            if vhfFmHomingCapable[typeName] == nil then
-                if tacanOnly[typeName] then
-                    freqType = "TACAN"
-                    modulation = 0
-                    csarGearGroupName = DF_UTILS.spawnGroupWide("TCN-".. coalitionId,csarPoint,"clone",2, false, {"LAND","ROAD"}, fName .. "_TCN")
-                else
-                    freqType = "NDB"
-                    modulation = 0
-                end
-            end
-            local freq = csarFreqs[coalitionId][freqType][csarCounter[coalitionId][freqType]]
-            local channel = csarCounter[coalitionId][freqType] + 1
-            local freqStr = "Use homing function of VHF radio - FM band - ".. freq / 1000000 .." MHz (Ch" .. channel .. ")"
-            if freqType == "NDB" then freqStr = "Use NDB/ADF homing function - AM band - ".. freq / 1000 .." kHz" end
-            if freqType == "TACAN" then freqStr = "Use TACAN homing function - ".. freq .."X" end
-            local args = {}
-            args.groupName = csarGroupName
-            args.freqType = freqType
-            args.freq = freq
-            args.amfm = modulation
-            args.soundFile = "l10n/DEFAULT/dah2.ogg"
-            args.equipment = csarGearGroupName
-            timer.scheduleFunction(csb.startTransmission, args, timer.getTime() + math.random(2,5))
-            assignments[coalitionId][playerName] = {
-                name = playerName,
-                target = csarGroupName,
-                groupID = playerGroupID,
-                startTime = timer.getTime(),
-                smokeTime = timer.getTime(),
-                smokeNum = smokeNum,
-                status = 0,
-                freq = freq,
-                coords = csarPoint,
-                contact = false,
-                hoverTime = 0,
-                fName = fName,
-                equipment = csarGearGroupName,
-                freqType = freqType
-            }
-            trigger.action.outTextForGroup(playerGroupID, "- CSAR mission assigned.\n- Rescue ".. fName ..".\n- ".. freqStr .. ".", 90, false)
-            if csarCounter[coalitionId][freqType] == 8 then csarCounter[coalitionId][freqType] = -1 end
-            csarCounter[coalitionId][freqType] = csarCounter[coalitionId][freqType] + 1
+    if #csarMissions[coalitionId] < 1 then
+        CSB.generateCsar(nil, coalitionId, nil, nil, nil, nil, nil, nil)
+    end
+    if not prev then
+        CSB.addCsarRadioMenuToGroup(playerGroupID, playerGroupName, coalitionId)
+    end
+    trigger.action.outTextForGroup(playerGroupID,"Checked-in. Check CSAR menu for active rescues.",30,false)
+end
+function CSB.wrappedGenerateCsar(inUnit,coalitionId,overWater,playerName)
+    -- check for ejection onto base for auto collection
+    if not coalitionId or coalitionId == 0 then return end
+    if not (inUnit and inUnit:isExist()) then return end
+    local pos = inUnit:getPoint()
+    local agl = Utils.getAGL(pos)
+    local p1 = {x = pos.x, y = 0, z = pos.z}
+    local cwispy = false
+    local volcanoName = nil
+    for volcano,lavaVent in pairs(floorIsLava) do
+        local p2 = {x = lavaVent.x, y = 0, z = lavaVent.z}
+        local dist = Utils.PointDistance(p1,p2)
+        if dist < csarAutoProcRadius then
+            cwispy = true
+            volcanoName = volcano
+            break
         end
     end
+    if cwispy then
+        trigger.action.outTextForCoalition(coalitionId, "Ejected pilot landed close to " .. volcanoName .. " and was picked up.",20,false)
+        --Object.destroy(inUnit) -- not sure if you can destroy a player connected object in MP
+        return
+    end
+    --local args = {inUnit = inUnit}
+    --local cleanUpTimer = 10
+    local anyTerrain = nil
+    pos = {x = pos.x, y = pos.y-agl, z = pos.z}
+    if overWater then
+        --cleanUpTimer = 5
+        anyTerrain = true
+    end
+    CSB.generateCsar(pos,coalitionId,nil,nil,100,anyTerrain,nil,playerName)
+    timer.scheduleFunction(CSB.cleanUpPilot,args,timer.getTime()+cleanUpTimer) -- not sure if you can destroy a player connected object in MP
 end
-function csb.trackCsar()
-    timer.scheduleFunction(csb.trackCsar, nil, timer:getTime() + trackCsarInterval)
+function CSB.generateCsar(csarPoint, coalitionId, freq, channel, csarRadius, anyTerrain, timeLimit, playerName)
+    local fName = ""
+    local smokeNum = math.random(0,4)
+    local generatedCsar = {}
+    local genPoint = nil
+    generatedCsar.coalition = coalitionId
+    if playerName then
+        fName = "ejected "..playerName.." "..genCsarCounter
+    elseif randomNames and randomNames.getNewName then
+        fName = randomNames.getNewName(coalitionId)
+    else
+        fName = "Chris Burnett "..genCsarCounter
+    end
+    generatedCsar.name = fName
+    if not csarRadius then csarRadius = csarZoneRadius end
+    if not csarPoint then csarPoint = csarPoints[coalitionId] end
+    env.info("in generateCsar with args :--- coalitionId: " .. coalitionId .. " csarPoint: x=" .. csarPoint.x .. ", y=" .. csarPoint.y .. ", z=" .. csarPoint.z .. " csarRadius: " .. csarRadius .. " anyTerrain: " .. tostring(anyTerrain), false)
+    if not anyTerrain then
+        generatedCsar.terrainLimit = {"LAND", "ROAD"}
+        for i=1,50 do
+            genPoint = Utils.MakeVec3(mist.getRandPointInCircle(csarPoint, csarRadius, nil, nil, nil))
+            if mist.isTerrainValid(genPoint,generatedCsar.terrainLimit) then break end
+        end
+    else
+        genPoint = Utils.MakeVec3(mist.getRandPointInCircle(csarPoint, csarRadius, nil, nil, nil))
+    end
+    local terrainHght = land.getHeight({x=genPoint.x, y=genPoint.z}) or 0
+    genPoint.y = terrainHght
+    generatedCsar.point = genPoint
+    generatedCsar.gearPoint = Utils.MakeVec3(mist.getRandPointInCircle(generatedCsar.point, 10, 5, nil, nil))
+    env.info("finished generating point: x=" .. generatedCsar.point.x .. ", y=" .. generatedCsar.point.y ..", z=" .. generatedCsar.point.z, false)
+    env.info("finished generating gearpoint: x=" .. generatedCsar.gearPoint.x .. ", y=" .. generatedCsar.gearPoint.y ..", z=" .. generatedCsar.gearPoint.z, false)
+    generatedCsar.smokeTime = timer.getTime() - 300
+    generatedCsar.smokeNum = smokeNum
+    generatedCsar.status = 0
+    generatedCsar.freq = freq
+    generatedCsar.channel = channel
+    generatedCsar.modulation = 0
+    generatedCsar.contacts = {}
+    generatedCsar.winchers = {}
+    local cloneSource = true
+    if not mist.DBs.groupsByName["SOS-"..coalitionId] then cloneSource = false end
+    env.info("about to create new CSAR unit for " .. fName .." - Clone source is: " .. tostring(cloneSource), false)
+    local isCreated = CSB.createCsarUnit(generatedCsar)
+    if not isCreated then
+        env.info("Failed to create CSAR unit", false)
+        return
+    end
+    genCsarCounter = genCsarCounter + 1
+    env.info("created new CSAR unit transmitting on " .. generatedCsar.freq * 10 .. "kHz/" .. generatedCsar.channel .. "X", false)
+    generatedCsar.startTime = timer.getTime()
+    if not timeLimit or #timeLimit ~= 2 then timeLimit = {csarTimeLimitMin, csarTimeLimitMax} end
+    local exp = math.random(math.floor(math.abs(timeLimit[2] - timeLimit[1]) / 60)) * 60
+    if timeLimit[2] < timeLimit[1] then timeLimit[1] = timeLimit[2] end
+    generatedCsar.expires = timeLimit[1] + exp
+    generatedCsar.skipWellness = true
+    if playerName then
+        generatedCsar.displayName = playerName
+    else
+        generatedCsar.displayName = fName
+    end
+    table.insert(csarMissions[coalitionId], generatedCsar)
+    trigger.action.outTextForCoalition(coalitionId, "- " .. generatedCsar.displayName .. " is requesting immediate extraction...\n - holding position for next " .. math.floor(generatedCsar.expires/60) .. " minutes...\n - broadcasting on " .. generatedCsar.freq * 10 .. "kHz/" .. generatedCsar.channel .. "X", 30, false)
+end
+function CSB.createCsarUnit(csarMissionTable)
+    local anyTerrain = false
+    if not csarMissionTable.terrainLimit then anyTerrain = true end
+    env.info("SOS - coalition: " .. csarMissionTable.coalition .. "| point: x=" .. csarMissionTable.point.x .. ", y=" .. csarMissionTable.point.y .. ", z=" .. csarMissionTable.point.z .. "| name: " .. csarMissionTable.name, false)
+    local csarGroupName = DF_UTILS.spawnGroupWide("SOS-".. csarMissionTable.coalition, csarMissionTable.point,"clone",2, anyTerrain, csarMissionTable.terrainLimit , csarMissionTable.name)
+    env.info("TCN - coalition: " .. csarMissionTable.coalition .. "| point: x=" .. csarMissionTable.gearPoint.x .. ", y=" .. csarMissionTable.gearPoint.y .. ", z=" .. csarMissionTable.gearPoint.z .. "| name: " .. csarMissionTable.name, false)
+    local csarGearGroupName = DF_UTILS.spawnGroupWide("TCN-".. csarMissionTable.coalition, csarMissionTable.gearPoint,"clone",2, anyTerrain, csarMissionTable.terrainLimit , csarMissionTable.name .. "-TCN")
+    if not csarGroupName or not csarGearGroupName then return false end
+    csarMissionTable.groupName = csarGroupName
+    csarMissionTable.equipment = csarGearGroupName
+    env.info("csarGroupName = " .. csarGroupName,false)
+    env.info("csarGearGroupName = " .. csarGearGroupName,false)
+    if not csarMissionTable.freq then
+        local ndbFreq = CSB.getClearFreq(csarMissionTable.coalition, "NDB", csarFreqs[csarMissionTable.coalition]["NDB"][1], csarFreqs[csarMissionTable.coalition]["NDB"][2])
+        csarMissionTable.freq = ndbFreq
+    end
+    if not csarMissionTable.channel then
+        csarMissionTable.channel = CSB.getClearFreq(csarMissionTable.coalition, "TACAN", csarFreqs[csarMissionTable.coalition]["TACAN"][1],csarFreqs[csarMissionTable.coalition]["TACAN"][2])
+    end
+    if csarMissionTable.freq == 0 or csarMissionTable.channel == 0 then return false end
+    local args = {}
+    args.groupName = csarGroupName
+    args.freq = csarMissionTable.freq
+    args.channel = csarMissionTable.channel
+    args.amfm = csarMissionTable.modulation
+    args.soundFile = "l10n/DEFAULT/dah2.ogg"
+    args.equipment = csarGearGroupName
+    timer.scheduleFunction(CSB.startTransmission, args, timer.getTime() + math.random(10,20))
+    return true
+end
+function CSB.getClearFreq(coalitionId,freqType,min,max)
+    local freq = 0
+    local breakVar = true
+    for j=1,50 do
+        freq = math.random(min,max)
+        for i,v in pairs(csarFreqCollisions[coalitionId][freqType]) do
+            if freq == v then
+                breakVar = false
+                break
+            end
+            breakVar = true
+        end
+        if breakVar then
+            for i,v in pairs(csarMissions[coalitionId]) do
+                if freqType == "NDB" then
+                    if freq == v.freq then
+                        breakVar = false
+                        break
+                    end
+                else
+                    if freq == v.channel then
+                        breakVar = false
+                        break
+                    end
+                end
+                breakVar = true
+            end
+        end
+        if breakVar then break end
+        if j==50 then 
+            env.info("Could not find a clear frequency for new CSAR",false)
+            return 0
+        end
+    end
+    return freq
+end
+function CSB.addCsarRadioMenuToGroup(groupID, groupName, coalitionId)
+    local csarSubMenu = missionCommands.addSubMenuForGroup(groupID, "CSAR", nil)
+    missionCommands.addCommandForGroup(groupID,"Show Active Rescues", csarSubMenu, CSB.showRescueList, {groupID = groupID, groupName = groupName, coalitionId = coalitionId})
+end
+function CSB.removeCsarRadioCommandsForGroup(groupID)
+    missionCommands.removeItemForGroup(groupID, {[1] = "CSAR"})
+end
+function CSB.showRescueList(args)
+    local playerGroup = Group.getByName(args.groupName)
+    if not (playerGroup and playerGroup:isExist()) then return end
+    local playerUnit = playerGroup:getUnit(1)
+    if not (playerUnit and playerUnit:isExist()) then return end
+    local playerPos = playerUnit:getPoint()
+    local rescueList = {}
+    for i,m in pairs(csarMissions[args.coalitionId]) do
+        table.insert(rescueList, m)
+        local r = Utils.PointDistance(playerPos, rescueList[#rescueList].point)
+        r = math.floor(r/10)/100
+        rescueList[#rescueList].range = r
+    end
+    local outString = " --- Open Evac Requests --- \n"
+    if #rescueList == 0 then
+        outString = outString .. "\nAll personnel accounted for.\n"
+        outString = outString .. "\n\nCheck-in at the CSAR stack(s) for new tasking.\n"
+    else
+        local rescueCount = #rescueList
+        local checkTime = timer.getTime()
+        local currentState = "GREEN ++ Safe ++ "
+        table.sort(rescueList, function (r1,r2) return r1.range < r2.range end)
+        if rescueCount > csarMaxDisplayed then rescueCount = csarMaxDisplayed end
+        for j=1,rescueCount do
+            local rescue = rescueList[j]
+            if rescue.expires then
+                local t = (rescue.startTime + rescue.expires) - checkTime
+                if t < csarTimeLimitMin * 0.25 then
+                    currentState = "RED __ Dire __ "
+                elseif t < csarTimeLimitMin * 0.5 then
+                    currentState = "ORANGE -- Worsening -- "
+                end
+            end
+            local nearestBase, dist, dir = CSB.closestBaseTo(rescue.point)
+            outString = outString .. "\n -> " .. rescue.displayName .. " | NDB/TACAN: " .. rescue.freq * 10 .. "kHz/" .. rescue.channel .. "X | " .. currentState .. " | LastKnown: apprx " .. dist .. "km " .. dir .. " of " .. nearestBase
+        end
+    end
+    trigger.action.outTextForGroup(args.groupID, outString, 30, false)
+end
+function CSB.closestBaseTo(p)
+    local closestBaseObj = nil
+    local closestBaseName = nil
+    local closestBaseDist = math.huge
+    local csarX = p.x
+    local csarZ = p.z
+    for n,o in pairs(floorIsLava) do
+        local xDiff = csarX - o.x
+        local zDiff = csarZ - o.z
+        local dist = (xDiff^2 + zDiff^2)^0.5
+        if dist < closestBaseDist then
+            closestBaseDist = dist
+            closestBaseName = n
+            closestBaseObj = o
+        end
+    end
+    local direction = Utils.relativeCompassBearing(p,closestBaseObj)
+    closestBaseDist = math.floor((closestBaseDist/1000)+0.5)
+    return closestBaseName, closestBaseDist, direction
+end
+function CSB.wellnessCheck(coalitionId)
+    local safeAsHouses = {}
+    local checkTime = timer.getTime()
+    for i,m in pairs(csarMissions[coalitionId]) do
+        if not m.skipWellness then
+            local timeLeft = true
+            local isAlive = true
+            if m.expires then timeLeft = (m.startTime + m.expires) > checkTime end
+            local rescueGroup = Group.getByName(m.groupName)
+            if not (rescueGroup and rescueGroup:isExist()) then isAlive = false end
+            if isAlive and timeLeft then
+                table.insert(safeAsHouses,m)
+            else
+                trigger.action.outTextForCoalition(coalitionId, "!!! " .. m.displayName .. "'s transponder is no longer active...",20,false)
+                CSB.cleanupCsarGroup(m)
+            end
+        else
+            m.skipWellness = nil
+            table.insert(safeAsHouses,m)
+        end
+    end
+    csarMissions[coalitionId] = safeAsHouses
+end
+function CSB.trackCsar()
+    timer.scheduleFunction(CSB.trackCsar, nil, timer:getTime() + trackCsarInterval)
     for c = 1, 2 do
         local playerActive = false
         local playerUnit = nil
-        for k,v in pairs(assignments[c]) do
+        local didYouEvenLift = false
+        CSB.wellnessCheck(c)
+        for k,v in pairs(csarCheckIns[c]) do
             local currentPlayers = coalition.getPlayers(c)
-            local targetGroup = nil
             for j = 1, #currentPlayers do
-                if v.name == Unit.getPlayerName(currentPlayers[j]) then
+                if k == Unit.getPlayerName(currentPlayers[j]) then
                     playerActive = true
                     playerUnit = currentPlayers[j]
                 end
             end
-            if playerActive and playerUnit then
-                if v.status == 0 then -- pre-pickup state
-                    targetGroup = Group.getByName(v.target)
-                    local isDead = false
-                    if targetGroup == nil or targetGroup:getSize() == 0 then
-                        isDead = true
-                    end
-                    if (isDead or (timer.getTime() - v.startTime > csarTimeLimit)) then
-                        csb.cleanupCsarGroup(v)
-                        trigger.action.outTextForGroup(v.groupID, v.fName.."'s locator Beacon no longer transmitting...Return to CSAR stack for further assignment.", 30, false)
-                        assignments[c][v.name] = nil
-                    else
-                        local playerPos = playerUnit:getPoint()
-                        local dist = Utils.PointDistance(playerPos, v.coords)
-                        local playerAgl = Utils.getAGL(playerPos)
-                        local playerHdg = Utils.getHdgFromPosition(playerUnit:getPosition())
-                        local clockBearing = Utils.relativeClockBearing(playerPos, v.coords, playerHdg)
-                        local playerTypeName = playerUnit:getTypeName()
-                        local pVelo = playerUnit:getVelocity()
-                        local inSafeVeloParams = csb.checkVelocity(pVelo,1.0)
+            if playerActive and playerUnit and DFS.heloCapacities[playerUnit:getTypeName()] then
+                local playerPos = playerUnit:getPoint()
+                local playerAgl = Utils.getAGL(playerPos)
+                local playerHdg = Utils.getHdgFromPosition(playerUnit:getPosition())
+                local playerTypeName = playerUnit:getTypeName()
+                local pUnitName = playerUnit:getName()
+                local pVelo = playerUnit:getVelocity()
+                local inSafeVeloParams = CSB.checkVelocity(pVelo,1.0)
+                v.typeName = playerTypeName -- keep it current in case relevant for weight/volume
+                local noRoomAtInn = false
+                local transporterTable = DFS.helos[v.groupName]
+                if transporterTable then
+                    if transporterTable.cargo.volumeUsed + csarTroopVol > DFS.heloCapacities[playerTypeName].volume then noRoomAtInn = true end
+                end
+                for i,m in pairs(csarMissions[c]) do
+                    if not m.skipWellness then
+                        local dist = Utils.PointDistance(playerPos, m.point)
+                        local clockBearing = Utils.relativeClockBearing(playerPos, m.point, playerHdg)
                         if dist < csarBreakCoverRange then
-                            if not v.contact then
+                            local pContacted = false
+                            for n,h in pairs(m.contacts) do
+                                if h == pUnitName then
+                                    pContacted = true
+                                    break
+                                end
+                            end
+                            if not pContacted then
                                 -- they do want this smoke
-                                local smokeColor = smokeColors[v.smokeNum]
-                                trigger.action.outTextForGroup(v.groupID, "This is " .. v.fName .. ", have eyes on - popping " .. smokeColor .. " smoke to your " .. clockBearing .. " o'clock.", 30, false)
-                                v.contact = true
-                                DFS.smokeGroup(v.target, v.smokeNum)
-                                v.smokeTime = timer.getTime()
+                                local smokeColor = smokeColors[m.smokeNum]
+                                trigger.action.outTextForGroup(v.groupID, "This is " .. m.displayName .. ", have eyes on - popping " .. smokeColor .. " smoke to your " .. clockBearing .. " o'clock.", 30, false)
+                                table.insert(m.contacts, pUnitName)
+                                if DFS and DFS.smokeGroup then DFS.smokeGroup(m.groupName, m.smokeNum) end
+                                if cb and cb.flareGroup then cb.flareGroup(m.groupName) end
+                                m.smokeTime = timer.getTime()
                             else
                                 -- too long
-                                if (timer.getTime() - v.smokeTime > 300) then
-                                    local smokeColor = smokeColors[v.smokeNum]
-                                    trigger.action.outTextForGroup(v.groupID, "This is " .. v.fName .. ", popping fresh " .. smokeColor .. " smoke to your " .. clockBearing .. " o'clock.", 30, false)
-                                    DFS.smokeGroup(v.target, v.smokeNum)
-                                    v.smokeTime = timer.getTime()
+                                if (timer.getTime() - m.smokeTime > 300) then
+                                    local smokeColor = smokeColors[m.smokeNum]
+                                    trigger.action.outTextForGroup(v.groupID, "This is " .. m.displayName .. ", popping fresh " .. smokeColor .. " smoke to your " .. clockBearing .. " o'clock.", 30, false)
+                                    if DFS and DFS.smokeGroup then DFS.smokeGroup(m.groupName, m.smokeNum) end
+                                    if cb and cb.flareGroup then cb.flareGroup(m.groupName) end
+                                    m.smokeTime = timer.getTime()
                                 end
                                 if dist < csarBreakCoverRange * 0.5 then
                                     local nicedist = math.floor(dist * 10)/10
                                     local outText = nil
-                                    if playerTypeName ~= "AV8BNA" then
-                                        outText = "Winch Op: " .. v.fName .. " approx. " .. nicedist .. "m to your " .. clockBearing .. " o'clock."
-                                        -- hover pick-up check
-                                        if dist < csarHoverRadius then
-                                            if playerAgl <= csarHoverAgl and playerAgl > 3 then
-                                                if inSafeVeloParams then
-                                                    local hoverTime = v.hoverTime
-                                                    if hoverTime == 0 then
-                                                        hoverTime = timer.getTime()
-                                                        v.hoverTime = timer.getTime()
-                                                    end
-                                                    hoverTime = timer.getTime() - hoverTime
-                                                    local countdown = math.floor(csarHoverTime - hoverTime)
-                                                    outText = "Winch Op: " .. nicedist .. "m to your " .. clockBearing .. " o'clock. Package inbound...(" .. countdown .. "s)"
-                                                    if hoverTime > csarHoverTime then
-                                                        outText = "Winch Op: Package secured. " .. v.fName .. " ready for RTB."
-                                                        csb.cleanupCsarGroup(v)
-                                                        v.status = 1
+                                    if noRoomAtInn then
+                                        outText = "The airframe is at it's volume limit. Extraction not possible."
+                                    else
+                                        if playerTypeName ~= "AV8BNA" and playerTypeName ~= "Yak-52" then
+                                            outText = "Winch Op: " .. m.displayName .. " approx. " .. nicedist .. "m to your " .. clockBearing .. " o'clock."
+                                            -- hover pick-up check
+                                            if dist < csarHoverRadius then
+                                                if playerAgl <= csarHoverAgl and playerAgl > 3 then
+                                                    if inSafeVeloParams then
+                                                        local hoverTime = m.winchers[pUnitName]
+                                                        if not hoverTime then
+                                                            hoverTime = timer.getTime()
+                                                            m.winchers[pUnitName] = timer.getTime()
+                                                        end
+                                                        hoverTime = timer.getTime() - hoverTime
+                                                        local countdown = math.floor(csarHoverTime - hoverTime)
+                                                        outText = "Winch Op: " .. nicedist .. "m to your " .. clockBearing .. " o'clock. Package inbound...(" .. countdown .. "s)"
+                                                        if hoverTime > csarHoverTime then
+                                                            outText = "Winch Op: Package secured. " .. m.name .. " ready for RTB."
+                                                            table.insert(v.onBoard,m)
+                                                            CSB.cleanupCsarGroup(m)
+                                                            m.status = 1
+                                                            didYouEvenLift = true
+                                                            transporterTable.addedMass = transporterTable.addedMass + csarTroopMass
+                                                            transporterTable.cargo.volumeUsed = transporterTable.cargo.volumeUsed + csarTroopVol
+                                                            trigger.action.setUnitInternalCargo(pUnitName, transporterTable.addedMass)
+                                                        end
+                                                    else
+                                                        outText = "Winch Op: We're drifting, need to lock in...package is " .. nicedist .. "m to your " .. clockBearing .. " o'clock."
                                                     end
                                                 else
-                                                    outText = "Winch Op: We're drifting...we need to stabilize the hover."
+                                                    if playerAgl > csarHoverAgl then
+                                                        outText = "Winch Op: " .. m.displayName .. " approx. " .. nicedist .. "m to your " .. clockBearing .. " o'clock - land, or descend to below " .. csarHoverAgl .. "m AGL for winching."
+                                                    elseif playerUnit:inAir() == false then -- could be on ground but was too fast when landing event was processed
+                                                        CSB.checkCsarLanding(playerUnit)
+                                                    end
+                                                    m.winchers[pUnitName] = nil
                                                 end
                                             else
-                                                if playerAgl > csarHoverAgl then
-                                                    outText = "Winch Op: " .. v.fName .. " approx. " .. nicedist .. "m to your " .. clockBearing .. " o'clock - land, or descend to below " .. csarHoverAgl .. "m AGL for winching."
-                                                elseif playerUnit:inAir() == false then -- could be on ground but was too fast when landing event was processed
-                                                    csb.checkCsarLanding(playerUnit)
-                                                end
-                                                v.hoverTime = 0
+                                                m.winchers[pUnitName] = nil
                                             end
-                                        else
-                                            v.hoverTime = 0
+                                            trigger.action.outTextForGroup(v.groupID, outText, 30 , true)
+                                            outText = nil
                                         end
                                     end
-                                    if outText then trigger.action.outTextForGroup(v.groupID, outText, 30 , true) end
+                                    if outText then trigger.action.outTextForGroup(v.groupID, outText, 30 , false) end
                                 else
-                                    v.hoverTime = 0
+                                    m.winchers[pUnitName] = nil
                                 end
                             end
                         end
                     end
-                elseif v.status == 1 then -- post-pickup state
-                    -- no-op
-                else -- unexpected status
-                    csb.cleanupCsarGroup(v)
-                    trigger.action.outTextForGroup(v.groupID, v.fName.."'s locator Beacon no longer transmitting...Return to CSAR stack for further assignment.", 30, false)
-                    assignments[c][v.name] = nil
-                end
+                end -- end of csar rescues for loop
             else
-                csb.cleanupCsarGroup(v)
-                assignments[c][v.name] = nil
+                -- player no longer CSAR-viable, check-out
+                csarCheckIns[c][k] = nil
+            end
+        end -- end of csar check-ins for loop
+        if didYouEvenLift then
+            local leanedOut = {}
+            for i,m in pairs(csarMissions[c]) do
+                if m.status == 0 then
+                    table.insert(leanedOut,m)
+                end
+            end
+            csarMissions[c] = leanedOut
+        end
+    end --end of coalition for loop
+end
+function CSB.refreshCsarTransmissions()
+    timer.scheduleFunction(CSB.refreshCsarTransmissions,nil,timer.getTime()+300)
+    for n=1,2 do
+        for i,m in pairs(csarMissions[n]) do
+            local args = {}
+            local cmd = {}
+            local targetGroup = Group.getByName(m.groupName)
+            if targetGroup and targetGroup:isExist() then
+                args.groupName = m.groupName
+                args.freq = m.freq
+                args.channel = m.channel
+                args.amfm = m.modulation
+                args.soundfile = "l10n/DEFAULT/dah2.ogg"
+                args.equipment = m.equipment
+                local aiCtrllr = targetGroup:getController()
+                if aiCtrllr and aiCtrllr.setCommand then
+                    cmd.params = {}
+                    cmd.id = "StopTransmission"
+                    aiCtrllr:setCommand(cmd)
+                    env.info("[CSB.refreshCsarTransmissions] - Stopping ".. m.freq*10000 .."kHz transmission by ".. args.groupName, false)
+                end
+                targetGroup = Group.getByName(args.equipment)
+                if targetGroup and targetGroup:isExist() then
+                    local eqCtrllr = targetGroup:getController()
+                    if eqCtrllr and eqCtrllr.setCommand then
+                        cmd = {}
+                        cmd.params = {}
+                        cmd.id = "DeactivateBeacon"
+                        eqCtrllr:setCommand(cmd)
+                        env.info("[CSB.refreshCsarTransmissions] - Stopping ".. m.channel .."X TACAN beacon of ".. args.equipment, false)
+                    end
+                end
+                timer.scheduleFunction(CSB.startTransmission,args,timer.getTime()+math.random(5))
             end
         end
     end
+    --trigger.action.outText("CSAR transmissions refreshed",30,false)
 end
-function csb.startTransmission(args)
+function CSB.startTransmission(args)
     local targetGroup = Group.getByName(args.groupName)
-    local radioFreq = args.freq
-    local freqType = args.freqType
+    local ndbFreq = args.freq
+    local tcnChn = args.channel
     local modulation = args.amfm
     local soundFile = args.soundFile
     local eq = args.equipment
+    env.info("[CSB.startTransmission] - about to test group: " .. args.groupName .. "...",false)
     if targetGroup == nil or targetGroup:getSize() == 0 then return end
     local u = targetGroup:getUnit(1)
+    env.info("[CSB.startTransmission] - about to test for unit...",false)
     if u == nil or not u:isExist() then return end
     local aiCtrllr = targetGroup:getController()
+    local eqCtrllr = nil
     if eq then
         targetGroup = Group.getByName(eq)
         if targetGroup and targetGroup:isExist() then
-            aiCtrllr = targetGroup:getController()
+            eqCtrllr = targetGroup:getController()
         end
     end
     local cmd = {}
-    if aiCtrllr then
-        if freqType ~= "TACAN" then
-            cmd.id = "SetFrequency"
-            cmd.params = {}
-            cmd.params.frequency = radioFreq
-            cmd.params.modulation = modulation
-            aiCtrllr:setCommand(cmd)
-            cmd = {}
-            cmd.id = "TransmitMessage"
-            cmd.params = {}
-            cmd.params.loop = true
-            cmd.params.file = soundFile
-        else
-            local chAdj = 64
-            local baseFreq = 1151
-            if radioFreq < 64 then
-                chAdj = 1
-                baseFreq = 962
-            end
-            cmd.id = "ActivateBeacon"
-            cmd.params = {}
-            cmd.params.type = 4
-            cmd.params.system = 18
-            cmd.params.bearing = true
-            cmd.params.callsign = "SOS"
-            cmd.params.frequency = (baseFreq + radioFreq - chAdj) * 1000000
-            cmd.params.channel = radioFreq
-        end
+    if aiCtrllr and aiCtrllr.setCommand then
+        env.info("[CSB.startTransmission] - about to set frequency to: " .. tostring(ndbFreq*10000) .. "...",false)
+        cmd.id = "SetFrequency"
+        cmd.params = {}
+        cmd.params.frequency = ndbFreq * 10000
+        cmd.params.modulation = modulation
+        cmd.params.power = 50
         aiCtrllr:setCommand(cmd)
+        cmd = {}
+        cmd.id = "TransmitMessage"
+        cmd.params = {}
+        cmd.params.loop = true
+        cmd.params.file = soundFile
+        aiCtrllr:setCommand(cmd)
+        env.info("[CSB.startTransmission] - TransmitMessage command sent...",false)
+    else
+        env.info("[CSB.startTransmission] - controller for CSAR unit is not functional.",false)
+    end
+    if eqCtrllr and eqCtrllr.setCommand then
+        local chAdj = 64
+        local baseFreq = 1151
+        if tcnChn < 64 then
+            chAdj = 1
+            baseFreq = 962
+        end
+        cmd = {}
+        cmd.id = "ActivateBeacon"
+        cmd.params = {}
+        cmd.params.type = 4
+        cmd.params.system = 18
+        cmd.params.bearing = true
+        cmd.params.callsign = "SOS"
+        cmd.params.frequency = (baseFreq + tcnChn - chAdj) * 1000000
+        cmd.params.channel = tcnChn
+        eqCtrllr:setCommand(cmd)
+    else
+        env.info("[CSB.startTransmission] - controller for CSAR TACAN unit is not functional.",false)
     end
 end
-function csb:onEvent(e)
+function CSB:onEvent(e)
     if not e.initiator then return end
     local evtInitr = e.initiator
-    if not (evtInitr and Unit.isExist(evtInitr) and evtInitr.getPlayerName and evtInitr:getPlayerName() and DFS.heloCapacities[evtInitr:getTypeName()]) then return end
-    -- we have a valid player initiated event from a CSAR-capable unit
     local evtId = e.id
-    if evtId == 4 or evtId == 55 then -- Landing
-        csb.checkCsarLanding(evtInitr)
+    local isCsarUnit = false
+    local playerName = nil
+    --//EJECTION EVENTS
+    if evtId == 6 then -- eject
+        local c = evtInitr:getCoalition()
+        if evtInitr.getPlayerName and evtInitr:getPlayerName() then playerName = evtInitr:getPlayerName() end
+        local isOverWater = false
+        if e.target then evtInitr = e.target end
+        if evtInitr.Desc then mist.utils.oneLineSerialize(evtInitr.Desc) end
+        local p = evtInitr:getPoint()
+        p.y = p.z
+        local terrtype = land.getSurfaceType(p)
+        if terrtype == 2 or terrtype == 3 then isOverWater = true end
+        CSB.wrappedGenerateCsar(evtInitr,c,isOverWater,playerName)
     end
-    --if evtId == 3 or evtId == 54 then -- takeoff
-        --csb.checkCsarTakeoff(evtInitr)
-    --end
-    if evtId == 5 then --crash
-        csb.checkCsarCrash(evtInitr)
+    if evtId == 33 then -- discard chair
+        local args = {inUnit = e.target}
+        timer.scheduleFunction(CSB.cleanUpPilot,args,timer.getTime()+5)
     end
-end
-function csb.checkCsarCrash(eUnit)
-    if eUnit and eUnit:isExist() and eUnit.getPlayerName then
-        local pName = eUnit:getPlayerName()
-        local pSide = eUnit:getCoalition()
-        if assignments[pSide][pName] then
-            local a = assignments[pSide][pName]
-            if a.status == 0 then
-                csb.cleanupCsarGroup(a)
-            end
-            assignments[pSide][pName] = nil
+    if evtId == 31 then -- pilot landed without being cleaned up somehow
+        if evtInitr.Desc then mist.utils.oneLineSerialize(evtInitr.Desc) end
+        local args = {inUnit = evtInitr}
+        timer.scheduleFunction(CSB.cleanUpPilot,args,timer.getTime()+5)
+    end
+    --//CSAR-CAPABLE INITIATOR EVENTS
+    isCsarUnit = evtInitr and Unit.isExist(evtInitr) and evtInitr.getPlayerName and evtInitr:getPlayerName() and DFS.heloCapacities[evtInitr:getTypeName()]
+    if isCsarUnit then
+        if evtId == 4 or evtId == 55 then -- Landing
+            CSB.checkCsarLanding(evtInitr)
+        end
+        if evtId == 5 then --crash
+            CSB.checkCsarCrash(evtInitr)
         end
     end
 end
-function csb.checkCsarLanding(eUnit)
+function CSB.checkCsarCrash(eUnit)
+    if eUnit and eUnit:isExist() and eUnit.getPlayerName then
+        -- unit probably doesn't have a group any more
+        local pName = eUnit:getPlayerName()
+        local pSide = eUnit:getCoalition()
+        if csarCheckIns[pSide][pName] then
+            csarCheckIns[pSide][pName] = nil
+        end
+    end
+end
+function CSB.checkCsarLanding(eUnit)
     if eUnit and eUnit:isExist() and eUnit.getPlayerName then
         local pName = eUnit:getPlayerName()
         local pSide = eUnit:getCoalition()
         local pPosn = eUnit:getPoint()
         local pVelo = eUnit:getVelocity()
-        local inSafeVeloParams = csb.checkVelocity(pVelo)
+        local inSafeVeloParams = CSB.checkVelocity(pVelo)
         local bInCsarBase = false
         local sBaseName = "Nowhere"
-        if assignments[pSide][pName] then
-            local tgt = assignments[pSide][pName].target
-            local fName = assignments[pSide][pName].fName
-            local coords = assignments[pSide][pName].coords
-            local eq = assignments[pSide][pName].equipment
-            local grpId = assignments[pSide][pName].groupID
+        if csarCheckIns[pSide][pName] then
             local zonePoint = nil
-            if assignments[pSide][pName].status == 1 then -- check for drop off
+            local csci = csarCheckIns[pSide][pName]
+            local transporterTable = DFS.helos[csci.groupName]
+            if #csci.onBoard > 0 then -- check for drop off
                 for j = 1, #csarBases[pSide] do
                     zonePoint = trigger.misc.getZone(csarBases[pSide][j])
                     if zonePoint then
@@ -500,67 +777,91 @@ function csb.checkCsarLanding(eUnit)
                                 bInCsarBase = true
                                 sBaseName = csarBases[pSide][j]
                             else
-                                trigger.action.outTextForGroup(grpId, "Travelling too fast for safe drop-off.", 30, false)
+                                trigger.action.outTextForGroup(csci.groupID, "Travelling too fast for safe drop-off.", 30, false)
                             end
                         end
                     end
                 end
                 if bInCsarBase then
-                    trigger.action.outTextForCoalition(pSide, pName .. " safely delivered " .. fName .. " to " .. sBaseName .. ".", 30, false)
-                    if DFS then
-                        DFS.status[pSide].health = DFS.status[pSide].health + 1
-                        DFS.updateHealthbar(pSide)
+                    for i,m in pairs(csci.onBoard) do
+                        trigger.action.outTextForCoalition(pSide, pName .. " safely delivered " .. m.displayName .. " to " .. sBaseName .. ".", 30, false)
+                        if DFS then
+                            DFS.status[pSide].health = DFS.status[pSide].health + 1
+                            DFS.updateHealthbar(pSide)
+                        end
+                        if WWEvents then WWEvents.playerCsarMissionCompleted(pName, pSide, sBaseName," rescued ".. m.displayName .. " from the battlefield.") end
                     end
-                    if WWEvents then WWEvents.playerCsarMissionCompleted(pName, pSide, sBaseName," rescued ".. fName .. " from the battlefield.") end
-                    assignments[pSide][pName] = nil
+                    if transporterTable then
+                        transporterTable.addedMass = transporterTable.addedMass - (#csci.onBoard * csarTroopMass)
+                        transporterTable.cargo.volumeUsed = transporterTable.cargo.volumeUsed - (#csci.onBoard * csarTroopVol)
+                        trigger.action.setUnitInternalCargo(csci.unitName, transporterTable.addedMass)
+                    end
+                    csci.onBoard = {}
                 end
             else -- check for pickup
-                if Utils.PointDistance(pPosn, coords) < csarPickupRadius then
-                    if inSafeVeloParams then
-                        trigger.action.outTextForCoalition(pSide, pName .. " is extracting " .. fName .. "...", 30, false)
-                        local args = {}
-                        args.pName = pName
-                        args.pSide = pSide
-                        args.target = tgt
-                        args.fName = fName
-                        args.equipment = eq
-                        args.pGrId = grpId
-                        args.pUnit = eUnit
-                        timer.scheduleFunction(csb.fakeExtractionTime, args, timer.getTime() + math.random(3,6))
-                    else
-                        trigger.action.outTextForGroup(grpId, "Travelling too fast for safe pickup.", 30, false)
+                for i,m in pairs(csarMissions[pSide]) do
+                    if Utils.PointDistance(pPosn, m.point) < csarPickupRadius then
+                        if inSafeVeloParams then
+                            trigger.action.outTextForCoalition(pSide, pName .. " is extracting " .. m.displayName .. "...", 30, false)
+                            local args = {}
+                            args.pName = pName
+                            args.pSide = pSide
+                            args.groupName = m.groupName
+                            args.fName = m.name
+                            args.equipment = m.equipment
+                            args.pGrId = csci.groupID
+                            args.pGrNm = csci.groupName
+                            args.pUnit = eUnit
+                            args.mission = m
+                            args.displayName = m.displayName
+                            timer.scheduleFunction(CSB.fakeExtractionTime, args, timer.getTime() + math.random(3,6))
+                        else
+                            trigger.action.outTextForGroup(csci.groupID, "Travelling too fast for safe pickup.", 30, false)
+                        end
                     end
                 end
             end
         end
     end
 end
-function csb.fakeExtractionTime(args)
+function CSB.fakeExtractionTime(args)
     local playerGroupID = args.pGrId
     local playerUnit = args.pUnit
+    local transporterTable = DFS.helos[args.pGrNm]
     if playerUnit and playerUnit:isExist() and playerUnit.getPlayerName then
         local pVelo = playerUnit:getVelocity()
-        local inSafeVeloParams = csb.checkVelocity(pVelo)
+        local pUnitName = playerUnit:getName()
+        local inSafeVeloParams = CSB.checkVelocity(pVelo)
         if inSafeVeloParams then
-            csb.cleanupCsarGroup(args)
-            trigger.action.outTextForCoalition(args.pSide, args.pName .. " has taken " .. args.fName .. " on board.", 30, true)
-            assignments[args.pSide][args.pName].status = 1
+            table.insert(csarCheckIns[args.pSide][args.pName].onBoard, args.mission)
+            if transporterTable then
+                transporterTable.addedMass = transporterTable.addedMass + csarTroopMass
+                transporterTable.cargo.volumeUsed = transporterTable.cargo.volumeUsed + csarTroopVol
+                trigger.action.setUnitInternalCargo(pUnitName, transporterTable.addedMass)
+            end
+            CSB.cleanupCsarGroup(args)
+            local filtered = {}
+            for i,m in pairs(csarMissions[args.pSide]) do
+                if m ~= args.mission then
+                    table.insert(filtered, m)
+                end
+            end
+            csarMissions[args.pSide] = filtered
+            trigger.action.outTextForCoalition(args.pSide, args.pName .. " has taken " .. args.displayName .. " on board.", 30, true)
         else
             trigger.action.outTextForGroup(playerGroupID, "Travelling too fast for safe pickup.", 30, false)
         end
     end
 end
-function csb.cleanupCsarGroup(csarData)
-    local targetGroup = Group.getByName(csarData.target)
-    if targetGroup and targetGroup:isExist() then
-        Group.destroy(targetGroup)
-        if csarData.equipment ~= nil then
-            local eq = Group.getByName(csarData.equipment)
-            if eq and eq:isExist() then Group.destroy(eq) end
-        end
+function CSB.cleanupCsarGroup(csarData)
+    local targetGroup = Group.getByName(csarData.groupName)
+    if targetGroup and targetGroup:isExist() then Group.destroy(targetGroup) end
+    if csarData.equipment ~= nil then
+        local eq = Group.getByName(csarData.equipment)
+        if eq and eq:isExist() then Group.destroy(eq) end
     end
 end
-function csb.checkVelocity(pVelo,limit)
+function CSB.checkVelocity(pVelo,limit)
     local vLimit = limit or 0.5
     if vLimit <= 0 then vLimit = 0.5 end
     local xInParam = math.abs(pVelo.x) < vLimit
@@ -568,5 +869,26 @@ function csb.checkVelocity(pVelo,limit)
     local zInParam = math.abs(pVelo.z) < vLimit
     return xInParam and yInParam and zInParam
 end
-world.addEventHandler(csb)
-csb.load()
+function CSB.buildLavaList()
+    local aybabtu = world.getAirbases()
+    for i, base in pairs(aybabtu) do
+        local baseType = base:getDesc().category
+        if baseType == 0 or baseType == 1 then
+            floorIsLava[base:getName()] = base:getPoint()
+        end
+    end
+end
+function CSB.cleanUpPilot(args)
+    local pilot = args.inUnit
+    if pilot and pilot:isExist() then Object.destroy(pilot) end
+end
+function CSB.debugCsarGeneration()
+    timer.scheduleFunction(CSB.debugCsarGeneration,nil,timer.getTime()+10)
+    for i=1,2 do
+        if #csarMissions[i] < 2 then
+            CSB.generateCsar(nil,i,nil,nil,nil,nil,nil,nil)
+        end
+    end
+end
+world.addEventHandler(CSB)
+CSB.load()

--- a/Components/CSARBot.lua
+++ b/Components/CSARBot.lua
@@ -257,7 +257,7 @@ function CSB.wrappedGenerateCsar(inUnit,coalitionId,overWater,playerName)
         anyTerrain = true
     end
     CSB.generateCsar(pos,coalitionId,nil,nil,100,anyTerrain,nil,playerName)
-    timer.scheduleFunction(CSB.cleanUpPilot,args,timer.getTime()+cleanUpTimer) -- not sure if you can destroy a player connected object in MP
+    --timer.scheduleFunction(CSB.cleanUpPilot,args,timer.getTime()+cleanUpTimer) -- not sure if you can destroy a player connected object in MP
 end
 function CSB.generateCsar(csarPoint, coalitionId, freq, channel, csarRadius, anyTerrain, timeLimit, playerName)
     local fName = ""

--- a/DF_Cauc.lua
+++ b/DF_Cauc.lua
@@ -644,6 +644,7 @@ function dfcEvents:onEvent(event)
                     missionCommands.removeItemForGroup(ID, nil)
                     if Sonobuoys then Sonobuoys.removeRadioCommandsForGroup(ID) end
                     if MAD then MAD.removeRadioCommandsForGroup(ID) end
+                    if CSB then CSB.removeCsarRadioCommandsForGroup(ID) end
                 end
             end
         end
@@ -658,6 +659,7 @@ function dfcEvents:onEvent(event)
                     missionCommands.removeItemForGroup(ID, nil)
                     if Sonobuoys then Sonobuoys.removeRadioCommandsForGroup(ID) end
                     if MAD then MAD.removeRadioCommandsForGroup(ID) end
+                    if CSB then CSB.removeCsarRadioCommandsForGroup(ID) end
                 end
             end
         end

--- a/Utils/df_utils.lua
+++ b/Utils/df_utils.lua
@@ -20,17 +20,18 @@ end
 function DF_UTILS.spawnGroupWide(groupName, spawnPoint, action, radius, anywhere, safeZones, fName)
     local vars = {}
         vars.gpName = groupName
-		if fName ~= "" then
-			vars.name = fName
+		if fName and fName ~= "" then
+			vars.newGroupName = fName
 		end
         vars.action = action
         vars.point = spawnPoint
         vars.radius = radius
+		vars.offsetWP1 = true
         vars.anyTerrain = anywhere
         if (not anywhere) and safeZones then
 			vars.validTerrain = safeZones
 		end
-        return mist.teleportToPoint(vars).name
+		return mist.teleportToPoint(vars).name
 end
 function DF_UTILS.fileExists(file)
     local f = io.open(file, 'rb')

--- a/Utils/utils.lua
+++ b/Utils/utils.lua
@@ -115,17 +115,30 @@ function Utils.relativeClockBearing(p1,p2,hdg)
     bearing = math.floor(bearing / math.pi * 180)
     bearing = bearing - hdg
     local clockBearing = math.fmod(bearing, 360)
-    while clockBearing < 0 do
-        clockBearing = clockBearing + 360
-    end
-    while clockBearing > 360 do
-        clockBearing = clockBearing - 360
-    end
+    if clockBearing < 0 then clockBearing = clockBearing + 360 end
     if clockBearing < 15 then
         return 12
     end
     clockBearing = clockBearing + 15
     return math.floor(clockBearing/30)
+end
+function Utils.relativeCompassBearing(p1,p2)
+    -- you are standing at p2 looking towards p1
+    local xdiff = p1.x - p2.x
+    local zdiff = p1.z - p2.z
+    local bearing = math.atan2(zdiff, xdiff)
+    bearing = math.floor(bearing / math.pi * 180)
+    if bearing > 360 then bearing = bearing - 360 end
+    if bearing < 0 then bearing = bearing + 360 end
+    if bearing < 23 then return "North" end
+    if bearing < 68 then return "NE" end
+    if bearing < 112 then return "East" end
+    if bearing < 158 then return "SE" end
+    if bearing < 202 then return "South" end
+    if bearing < 248 then return "SW" end
+    if bearing < 292 then return "West" end
+    if bearing < 338 then return "NW" end
+    return "North"
 end
 function Utils.pointInCircleTriggerZone(pp,zp)
     local pZeroAlt = {x = pp.x, y = 0, z = pp.z}


### PR DESCRIPTION
- adds a F10 menu on CSAR check-in that lists active rescues.
- when checking-in, if there are no rescues then one will be generated in the CSAR zone
- human ejections become rescue targets, over water or land, but will be auto-collected if within a certain distance of a enemy/friendly base
- all rescues have a random time limit between 20 and 40 mins, the list of active rescues shows the status and changes it from Green to Orange at 50% time left, and to Red at 25% time left. Should be sweaty. Timer turns off when you collect the rescue.
- rescued people take up 2 volume and add 130kg to the cargo load
If this version doesn't break too hard then another CSAR base per team, and other CSAR return points will be added to the mission.
v3 plan is for the rescue to be opposed by a small group of enemies dispatched by road/air to capture the soldier if they are close to/in enemy territory.